### PR TITLE
Add article from The Asahi Shimbun

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ This section is a great place to start if you want to get into improving OpenStr
 
 ## Articles
 
-* [Volunteer armies map ‘invisible’ communities hit by coronavirus](https://www.asahi.com/ajw/articles/13729507) - Amid the coronavirus outbreak OpenStreetMap contributors mapped over 1,100 handwashing stations. (5 min read, 2020-10-15, The Asahi Shimbun)
+* [Volunteer armies map ‘invisible’ communities hit by coronavirus](https://www.asahi.com/ajw/articles/13729507) - OpenStreetMap contributors map over 1,100 handwashing stations. (5 min read, 2020-10-15, The Asahi Shimbun)
 
 ## Communities
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ This section is a great place to start if you want to get into improving OpenStr
 
 ## Articles
 
+* [Volunteer armies map ‘invisible’ communities hit by coronavirus](https://www.asahi.com/ajw/articles/13729507) - Amid the coronavirus outbreak OpenStreetMap contributors mapped over 1,100 handwashing stations. (5 min read, 2020-10-15, The Asahi Shimbun)
+
 ## Communities
 
 ### Global Communities


### PR DESCRIPTION
This PR adds the Article "[Volunteer armies map ‘invisible’ communities hit by coronavirus](https://www.asahi.com/ajw/articles/13729507)" from The Asahi Shimbun