### PR TITLE
Update Linter Configuration

### DIFF
--- a/.github/workflows/link-lint.config.json
+++ b/.github/workflows/link-lint.config.json
@@ -1,0 +1,6 @@
+{
+    "timeout": "20s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s"
+}

--- a/.github/workflows/link-lint.yml
+++ b/.github/workflows/link-lint.yml
@@ -17,6 +17,8 @@ jobs:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       id: linter
+      with:
+        config-file: ".github/link-lint.config.json"
     - name: Issue on failure
       if: ${{ failure() }}
       uses: JasonEtco/create-an-issue@v2


### PR DESCRIPTION
The Linter currently fails on HTTP-Error 429, which indicates the linter being rate-limited. This PR will correct that.