### PR TITLE
Move Deriviste to unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ We also have a list of <a href="UNMAINTAINED.md">unmaintained projects</a>. If y
 * [Rapid](https://rapideditor.org/edit) - AI assisted versions of iD. ([Meta-Repo](https://github.com/facebookmicrosites/Open-Mapping-At-Facebook) / [Editor Source Code](https://github.com/facebook/Rapid) / [Wiki](https://wiki.openstreetmap.org/wiki/RapiD))
 * [OSMyBiz](https://osmybiz.osm.ch) - Website for managing informations about your business. ([Source Code](https://gitlab.com/geometalab/osmybiz) / [Wiki](https://wiki.openstreetmap.org/wiki/OSMyBiz))
 * [OnOSM](https://www.onosm.org/) - Allows anyone to submit business information as a note for inclusion into OSM. ([Source Code](https://github.com/osmlab/onosm.org) / [Wiki](https://wiki.openstreetmap.org/wiki/Onosm.org))
-* [Deriviste](https://osm.cycle.travel/deriviste/) - Provides a simple interface to add nodes to OpenStreetMap based on what you see in Mapillary street-level imagery. ([Source Code](https://github.com/systemed/deriviste) / [Wiki](https://wiki.openstreetmap.org/wiki/Deriviste))
 * [Healthsites.io](https://healthsites.io/map) - An online editor focused on adding and improving data on global health facilities. ([Source Code](https://github.com/healthsites/healthsites/) / [Wiki](https://wiki.openstreetmap.org/wiki/Healthsites.io))
 
 ### Mobile Editors

--- a/UNMAINTAINED.md
+++ b/UNMAINTAINED.md
@@ -10,8 +10,18 @@ If you are a developer, consider looking through those projects and adopting one
 
 ## Contents
 
+* [Editors](#editors)
+  * [Web Editors](#web-editors)
 * [Tools](#tools)
   * [Web Tools](#web-tools)
+
+
+## Editors
+
+### Web Editors
+
+* [Deriviste](https://osm.cycle.travel/deriviste/) - Provides a simple interface to add nodes to OpenStreetMap based on what you see in Mapillary street-level imagery. ([Source Code](https://github.com/systemed/deriviste) / [Wiki](https://wiki.openstreetmap.org/wiki/Deriviste))
+
 
 ## Tools
 


### PR DESCRIPTION
Deriviste uses login/password authentication, which is no longer supported by osm.org. The last commit in the repository was 5 years ago