### PR TITLE
Update CI Workflow

### DIFF
--- a/.github/workflows/awesome-lint.yml
+++ b/.github/workflows/awesome-lint.yml
@@ -9,7 +9,7 @@ jobs:
   Awesome_Lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: npx awesome-lint


### PR DESCRIPTION
This PR updates the workflow to use actions/checkout@v4 instead of v3.