### PR TITLE
Added new Map/Tile Providers section containing OpenFreeMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ We also have a list of <a href="UNMAINTAINED.md">unmaintained projects</a>. If y
   * [Mobile Maps](#mobile-maps)
   * [Generators](#generators)
   * [Map Styles](#map-styles)
+  * [Map/Tile Providers](#maptile-providers)
   * [Map Games](#map-games)
   * [Goal Tracking](#goal-tracking)
 * [Libraries](#libraries)

--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ This section is a great place to start if you want to get into improving OpenStr
 
 * [Terrain Classic](https://github.com/stamen/terrain-classic) - World-wide CartoCSS port of Stamen's classic terrain style.
 
+### Map/Tile Providers
+
+* [OpenFreeMap](https://openfreemap.org/) - Free, production-quality OpenStreetMap vector-tile hosting of the entire planet. No limits, no registration, no user database, no API keys, and no cookies. ([Source Code](https://github.com/hyperknot/openfreemap))
+
 ### Map Games
 
 * [Back Of Your Hand](https://backofyourhand.com/) - A web map game that tests your knowledge by having you find a street in a given area. ([Source Code](https://github.com/adam-lynch/back-of-your-hand))


### PR DESCRIPTION
Added a section for Map/Tile Providers with [OpenFreeMap](https://openfreemap.org/) details.