### PR TITLE
Add Pumperly to Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [Pumperly](https://pumperly.com) - Fuel price comparison and EV charging route planner across 36 countries, built on Valhalla routing, Photon geocoding, and OpenFreeMap tiles. ([Source Code](https://github.com/GeiserX/pumperly))
 
 ### Mobile Maps
 


### PR DESCRIPTION
## Summary

- Adds [Pumperly](https://pumperly.com) to the **Web Maps** section
- Pumperly is an open-source (GPL-3.0) fuel price comparison and EV charging route planner covering 36 countries, built on OpenStreetMap data via Valhalla routing, Photon geocoding, and OpenFreeMap tiles
- Self-hostable, source at https://github.com/GeiserX/pumperly

PS. Signed by me, Sergio Fernández (a human being)