### PR TITLE
Add MGuide to Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [MGuide](https://mguide.app) - Interactive campus map for the University of Michigan with 354 buildings, walking directions, and real-time bus tracking. Uses OSM-based CARTO basemaps.
 
 ### Mobile Maps
 


### PR DESCRIPTION
MGuide (https://mguide.app) is an interactive campus map for the University of Michigan. It renders 354 buildings with walking directions and real-time bus tracking on top of OSM-based CARTO basemaps (dark-matter, positron, voyager) via MapLibre GL JS.