### PR TITLE
Add MapMC to Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ This section is a great place to start if you want to get into improving OpenStr
 
 * [MyOSMatic](https://print.get-map.org/new/) - Website for generating printable street maps from OSM data. ([Source Code](https://github.com/hholzgra/maposmatic/))
 * [Field Papers](http://fieldpapers.org/) - Generate maps for printing, annotate them, and manage your notes after. ([Source Code](https://github.com/fieldpapers/fieldpapers) / [Wiki](https://wiki.openstreetmap.org/wiki/Field_Papers))
+* [MapMC](https://mapmc.app) - Generates downloadable Minecraft worlds (.mcworld) from OpenStreetMap data for any real-world location.
 
 ### Map Styles
 


### PR DESCRIPTION
Hi! Adding **MapMC** to the `Generators` section, alongside MyOSMatic and Field Papers.

### What it is
MapMC is a web app that turns any real-world location into a downloadable Minecraft world (`.mcworld`) using OpenStreetMap data — buildings, roads, and terrain. Runs in the browser, supports Java and Bedrock.

### Qualifies per CONTRIBUTING
- Uses OpenStreetMap data for a creative purpose (this list's focus)
- Live and public — free credit to try, no card required
- Single-line addition at the bottom of the Generators category, format matched

### Disclosure
I'm the maker of MapMC. Thanks for maintaining this list!