### PR TITLE
Add two OSM-powered apps from Korea (currency map + isochrone analyzer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ This section is a great place to start if you want to get into improving OpenStr
 
 ## Maps
 
+
+- [Gyeonggi Currency Map](https://gyeonggi-currency-map.web.app) - PWA mapping local-currency merchant locations across 31 cities of Gyeonggi Province (South Korea, 14M residents). OSM tiles via Leaflet, public open data, real-time "open now" filter.
+- [GeoInfomatic — Living Zone Accessibility](https://geoinfomatic.pythonanywhere.com) - Isochrone-based neighborhood accessibility analyzer for Korea. OSM-based walking graph (OSRM), isochrones rendered as Leaflet polygons, multi-facility analysis (school/hospital/mart/park/etc).
 ### Web Maps
 
 * [Baato Before-After Maps](https://beforeafter.baato.io/) - Generate before-after maps to visualize the work your local community has done. ([Source Code](https://github.com/baato/before-after))


### PR DESCRIPTION
Two real-world OSM consumers in production in South Korea:

1. **Gyeonggi Currency Map** — https://gyeonggi-currency-map.web.app
   31-city merchant search PWA over OSM tiles via Leaflet. Used by residents who get 6-10% cashback on top-ups but struggle to find participating merchants.

2. **GeoInfomatic** — https://geoinfomatic.pythonanywhere.com
   Walking isochrones generated from an OSRM walking-graph mesh, overlaid as Leaflet polygons. Multi-facility analysis (school, hospital, mart, park, gym, pharmacy, library, cafe) within reach.

Both solo-built. Sharing because both are non-toy real-world OSM use cases. Happy to revise sections.
