### PR TITLE
Add SafeStreets to Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [SafeStreets](https://safestreets.streetsandcommons.com) - Free address-level walkability and pedestrian-safety analysis, scoring any neighborhood on a 15-minute-city framework using OpenStreetMap data.
 
 ### Mobile Maps
 


### PR DESCRIPTION
Adds [SafeStreets](https://safestreets.streetsandcommons.com) to the **Web Maps** section.

SafeStreets is a free, OpenStreetMap-based web map that gives address-level walkability and pedestrian-safety scores on a 15-minute-city framework (daily-needs reach, pedestrian safety, transit access, walking comfort), with crash-based pedestrian risk analysis. It's similar in spirit to AccessMap, which is already listed.

- Entry added to the bottom of the Web Maps category, per CONTRIBUTING.
- Repository / project link: https://safestreets.streetsandcommons.com