### PR TITLE
Add MapMC to Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ This section is a great place to start if you want to get into improving OpenStr
 
 * [MyOSMatic](https://print.get-map.org/new/) - Website for generating printable street maps from OSM data. ([Source Code](https://github.com/hholzgra/maposmatic/))
 * [Field Papers](http://fieldpapers.org/) - Generate maps for printing, annotate them, and manage your notes after. ([Source Code](https://github.com/fieldpapers/fieldpapers) / [Wiki](https://wiki.openstreetmap.org/wiki/Field_Papers))
+* [MapMC](https://mapmc.app/) - Generate downloadable Minecraft worlds from OpenStreetMap data.
 
 ### Map Styles
 


### PR DESCRIPTION
## Summary

- Add MapMC to the Generators section.
- MapMC generates downloadable Minecraft worlds from OpenStreetMap data.

## Notes

- This is a single-item addition at the bottom of the relevant category, following CONTRIBUTING.md.
- Disclosure: I am the maker of MapMC.

Project link: https://mapmc.app/