### PR TITLE
Add Room TBA

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [Room TBA](https://room-tba.uplbtools.me) - Campus room finder for a Philippine university with class schedules, transit routes, and offline PWA sync. ([Source Code](https://github.com/uplbtools/room-tba))
 
 ### Mobile Maps
 


### PR DESCRIPTION
## Summary
Adds [Room TBA](https://room-tba.uplbtools.me) to **Maps > Web Maps**: a campus room finder built on OpenStreetMap data with schedules, transit routes, and offline PWA sync.

- Live: https://room-tba.uplbtools.me
- Source: https://github.com/uplbtools/room-tba
- License: MIT

## Test plan
- [x] Added at bottom of Web Maps section
- [x] Includes Source Code link