### PR TITLE
Add Działkopedia to Maps > Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [Działkopedia](https://dzialkopedia.pl) - Polish land-parcel checker that renders OpenStreetMap tiles alongside cadastral (GUGiK), zoning and transaction-price data.
 
 ### Mobile Maps
 


### PR DESCRIPTION
Adds Działkopedia (https://dzialkopedia.pl) under Maps > Web Maps. A Polish land-parcel checker that renders OpenStreetMap tiles as its basemap alongside cadastral (GUGiK), zoning and transaction-price data. It's also listed on the wiki: https://wiki.openstreetmap.org/wiki/They_are_using_OpenStreetMap (GIS section). Thanks for maintaining this list.