### PR TITLE
Add Seamap and Seascape to Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [Seascape](https://openwaters.io/charts/seascape) - Open source global bathymetry tiles (depth shading, contours, soundings) that pair with OSM basemaps; uses OSM land polygons for land/water masking. ([Source Code](https://github.com/openwatersio/seascape))
 
 ### Mobile Maps
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [Seamap](https://openwaters.io/charts/seamap) - A nautical chart rendered from OSM `seamark:*` tags and everyday tags like `leisure=marina`: buoys and beacons with IALA colours and topmarks, lights with sector arcs and characteristics, hazards, and traffic separation schemes. Rebuilt weekly, so edits appear on the chart with the next build. ([Source Code](https://github.com/openwatersio/seamap))
 * [Seascape](https://openwaters.io/charts/seascape) - Open source global bathymetry tiles (depth shading, contours, soundings) that pair with OSM basemaps; uses OSM land polygons for land/water masking. ([Source Code](https://github.com/openwatersio/seascape))
 
 ### Mobile Maps


### PR DESCRIPTION
Two entries from the same project.

Seamap is a nautical chart rendered from OSM data: `seamark:*` tags for buoys, beacons, lights with their sector arcs and characteristics, hazards and traffic separation schemes, plus everyday tags like `leisure=marina` and `leisure=slipway` for shore facilities. It rebuilds weekly from the planet file, so an edit shows up on the chart with the next build, and the viewer has an inspect control that shows the OSM tags behind whatever is under the cursor.

Seascape publishes free bathymetry tiles designed to sit under or alongside OSM basemaps, and OSM data is part of that pipeline too: the osmdata.openstreetmap.de land polygons mask coarse bathymetry at the shoreline, credited in the tile attribution.

Both are free to use with attribution, no API key. Disclosure: I'm the author.
