### PR TITLE
Add PlaySG to Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [PlaySG](https://playsg.sg) - A map of every playground in Singapore (~2,300 from OSM data, refreshed weekly) with shade, water play and age-fit details for parents.
 
 ### Mobile Maps
 


### PR DESCRIPTION
Adds PlaySG (https://playsg.sg) to the Web Maps section.

PlaySG maps every playground in Singapore (~2,300, sourced from OSM leisure=playground via Overpass, refreshed weekly) and adds parent-oriented details: shade, water play, age fit, ratings and the nearest MRT station. Free, no ads, no account. Built with MapLibre GL; OSM attribution and per-object source links to openstreetmap.org included.

Disclosure: I am the author. The entry follows the format of other regional civic maps in the section (e.g. Defikarte.ch).