### PR TITLE
Add Castlemap to the list of mapping resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
-* [Castlemap](https://thecastlemap.com) - Night-themed web map of 2,400 castles, fortresses and palaces worldwide, rendering OpenStreetMap vector tiles (via OpenFreeMap) with landmark data from Wikidata.
+* [Castlemap](https://thecastlemap.com) - Night-themed web map of 7,044 castles, fortresses and palaces worldwide, rendering OpenStreetMap vector tiles (via OpenFreeMap) with landmark data from Wikidata.
 
 ### Mobile Maps
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
-* [Castlemap](https://thecastlemap.com) - Night-themed web map of 7,044 castles, fortresses and palaces worldwide, rendering OpenStreetMap vector tiles (via OpenFreeMap) with landmark data from Wikidata.
+* [Castlemap](https://thecastlemap.com) - Night-themed web map of 7,738 castles, fortresses and palaces worldwide, rendering OpenStreetMap vector tiles (via OpenFreeMap) with landmark data from Wikidata.
 
 ### Mobile Maps
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [Castlemap](https://thecastlemap.com) - Night-themed web map of 2,400 castles, fortresses and palaces worldwide, rendering OpenStreetMap vector tiles (via OpenFreeMap) with landmark data from Wikidata.
 
 ### Mobile Maps
 


### PR DESCRIPTION
Adds Castlemap to Web Maps. It renders OpenStreetMap data via OpenFreeMap vector tiles (MapLibre GL JS) on a night basemap, with 7,738 castles, fortresses and palaces worldwide plotted from Wikidata. Free, no accounts, no ads; every landmark has its own page and the dataset is open (CC0). Thanks for maintaining the list!