### PR TITLE
Add World Train Map to Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
-* [TrainRouter](https://trainrouter.com) - Interactive atlas of 767 notable passenger train routes worldwide, rendered on OpenStreetMap-based OpenFreeMap vector tiles; the underlying rail dataset is open (CC BY 4.0).
+* [World Train Map](https://worldtrainmap.com) - Interactive atlas of over a thousand notable passenger train routes worldwide, with route alignments traced from OpenStreetMap railway relations and rendered on OpenFreeMap vector tiles (MapLibre GL JS). The route dataset is open (CC BY 4.0).
 
 ### Mobile Maps
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [TrainRouter](https://trainrouter.com) - Interactive atlas of 767 notable passenger train routes worldwide, rendered on OpenStreetMap-based OpenFreeMap vector tiles; the underlying rail dataset is open (CC BY 4.0).
 
 ### Mobile Maps
 


### PR DESCRIPTION
Adds [World Train Map](https://worldtrainmap.com) to Web Maps, at the bottom of the category per CONTRIBUTING.

It is a free, no-signup interactive atlas of the world's notable passenger train routes. The OSM part is the substantive part: route alignments are traced from OpenStreetMap railway relations way by way, rather than snapped to whatever track happens to be nearby, and the map renders OpenStreetMap-based OpenFreeMap vector tiles with MapLibre GL JS. Where a route's geometry comes from OSM, that geometry is © OpenStreetMap contributors, ODbL.

Two notes, since this PR has been open a while and I have just pushed a change to it:

* The site was renamed and moved. It was TrainRouter at trainrouter.com when I opened this; it is now World Train Map at worldtrainmap.com. The old domain redirects, but the entry should name the live one.
* I have taken the route and country counts out of the description on purpose. The original said 767 routes across 118 countries, and that number was already stale, which is exactly the kind of maintenance burden a list like this should not have to carry.

I built it solo. There is an ongoing thread about the project on the OSM community forum, where mappers have been finding and correcting real errors in the routes: https://community.openstreetmap.org/t/146020

Thanks for maintaining the list.