### PR TITLE
Add OSM2CDR to Web Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ We also have a list of <a href="UNMAINTAINED.md">unmaintained projects</a>. If y
 * [OSM Statistics](https://piebro.github.io/openstreetmap-statistics/) - Up-to-date OSM statistics about editor usage, corporate contributions and more.
 * [Bellingcat OpenStreetMap search](https://osm-search.bellingcat.com/) - Web based tool to find geolocation leads by searching for proximate features on OpenStreetMap. ([Source Code](https://github.com/bellingcat/osm-search) / [Article](https://www.bellingcat.com/resources/how-tos/2023/05/08/finding-geolocation-leads-with-bellingcats-openstreetmap-search-tool/))
 * [Ultra](https://overpass-ultra.us/) - Web based tool for making maps with a variety of data APIs such as overpass, postpass, qlever, ohsome, sophox, and more. ([Source Code](https://gitlab.com/trailstash/ultra))
+* [OSM2CDR](https://osm2cdr.com/) - Web service exporting OSM data for a selected area or administrative boundary into 62+ vector, CAD and 3D formats (CDR, DWG, DXF, SVG, STL and more) with map layers kept editable.
 
 ### Mobile Tools
 


### PR DESCRIPTION
Adds [OSM2CDR](https://osm2cdr.com/) — a web service that exports OSM data for a selected area or administrative boundary into 62+ vector, CAD and 3D formats (CDR, DWG, DXF, SVG, STL and more), keeping map layers editable in the target application.

Typical uses: signage/print design in vector editors, CAD site plans, laser engraving (DXF), 3D-printed city maps (STL). Exported data is © OpenStreetMap contributors (ODbL); attribution is embedded in every export.

Added at the bottom of the Web Tools category per the contribution guidelines.