### PR TITLE
Add League of Spin to Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [League of Spin](https://leagueofspin.com) - A map of 27,000+ outdoor ping-pong/table-tennis tables worldwide, sourced from OpenStreetMap plus user submissions, with spot details and live playing conditions.
 
 ### Mobile Maps
 


### PR DESCRIPTION
Adds League of Spin (https://leagueofspin.com), a web map of 27,000+ outdoor ping-pong/table-tennis tables worldwide, sourced from OpenStreetMap data plus user submissions, with spot details and live playing conditions. Same pattern as the existing openclimbing.org entry — a niche-sport map built on OSM.