### PR TITLE
Add MideaFind OSM store-coverage map

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [MideaFind](https://mideafind.com/marktabdeckung-karte.html) - Maps a dated snapshot of known German DIY-store locations from OpenStreetMap, with a public quality report and explicit coverage-versus-inventory limits.
 
 ### Mobile Maps
 


### PR DESCRIPTION
## Summary

Adds MideaFind to the Web Maps section as a German OpenStreetMap-derived DIY-store coverage map.

## Why it fits

- The public map uses a dated OSM/Overpass snapshot.
- Its public quality report documents 1,314 known locations across six retail groups.
- It explicitly distinguishes geographic coverage from product inventory.

## Validation

- Landing page: HTTP 200
- Quality report: HTTP 200
- STAC catalog: HTTP 200
- `git diff --check` passed

Disclosure: I operate MideaFind.