### PR TITLE
Add Brünneli to Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ The services in this category allow you to track personal and fitness goals util
 * [OpenGeofiction](https://opengeofiction.net/) - A completely fictional user-made world map, created using the OSM software platform. ([Wiki](https://wiki.openstreetmap.org/wiki/OpenGeofiction))
 * [OSM Monitor](https://osm-monitor.com/) - A website to monitor and display new OSM edits. ([Source Code](https://github.com/johanmorganti/osm-datadog))
 * [OpenHistoricalMap](https://www.openhistoricalmap.org/) - Mapping places throughout the world… throughout the ages, created using the OSM software platform. ([Wiki](https://wiki.openstreetmap.org/wiki/OpenHistoricalMap))
+* [Brünneli](https://bruenneli.vercel.app) - Finds the nearest public drinking fountain in Switzerland and gives walking directions to it. Basel and Zürich use verified municipal open data; the rest of the country is covered by OpenStreetMap drinking-water points.
 
 ## Video
 


### PR DESCRIPTION
Adds [Brünneli](https://bruenneli.vercel.app), a small web app that finds the nearest public drinking fountain in Switzerland and gives walking directions to it.

Basel and Zürich use verified municipal open data; the rest of the country is covered by OpenStreetMap `amenity=drinking_water` points.