### PR TITLE
Add BookNear.me to Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [BookNear.me](https://booknear.me) - Finds bookshops, libraries and public bookcases near a location worldwide, with an open no-key API. ([Source Code](https://github.com/aabhisrv/booknear.me))
 
 ### Mobile Maps
 


### PR DESCRIPTION
Adds [BookNear.me](https://booknear.me) to **Maps → Web Maps**.

It renders three tags — `shop=books`, `amenity=library` and `amenity=public_bookcase` — for any
point on earth, from live Overpass data. `public_bookcase` is the reason I built it: very little
renders that tag, and putting it beside bookshops and libraries makes its coverage gaps obvious
(16 within 8 km of central Berlin, 1 in Bangalore, 0 in Varanasi). Every result links to its OSM
object and empty areas link to fixthemap, so it nudges people toward surveying rather than just
consuming.

It's free, needs no account, sets no cookies and carries no ads, and there's an open no-key JSON
API with ODbL attribution on every response. Overpass answers are cached for a week per ~1 km
cell so the upstream gets asked each question once.

Source: https://github.com/aabhisrv/booknear.me

Checklist against CONTRIBUTING:
- Searched the list first — no existing entry for this or an equivalent bookshop/bookcase map.
- Single suggestion in this PR.
- Added to the bottom of the relevant category.
- Format matches the surrounding entries, including the `([Source Code](...))` suffix.