### PR TITLE
Add MTL Explorer to Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [MTL Explorer](https://mindalyze-com.github.io/mtl-explorer/) - Self-hosted GPS track archive with OpenStreetMap-based maps, activity analysis, filtering, and route planning. ([Source Code](https://github.com/mindalyze-com/mtl-explorer))
 
 ### Mobile Maps
 


### PR DESCRIPTION
Adds MTL Explorer under Maps → Web Maps.

MTL Explorer is an AGPL-3.0-or-later self-hosted GPS track archive. It uses OpenStreetMap raster and vector maps, OSM-based Waymarked Trails overlays, and BRouter routing.

Project: https://mindalyze-com.github.io/mtl-explorer/
Repository: https://github.com/mindalyze-com/mtl-explorer