### PR TITLE
Add Camping-Karte dachlast.de to Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [Camping-Karte dachlast.de](https://dachlast.de/camping-karte.html) - Camping map with route planner for Germany and neighbouring countries: campsites, RV pitches, drinking water, sanitary facilities, charging and fuel stations from OSM data (German).
 
 ### Mobile Maps
 


### PR DESCRIPTION
Adds Camping-Karte (https://dachlast.de/camping-karte.html) to the Web Maps section: an OSM-based camping map for Germany and neighbouring countries with a route planner - campsites, RV pitches, drinking water, sanitary facilities, charging and fuel stations. ODbL attribution on the page; the site also publishes its own datasets under CC BY 4.0.