### PR TITLE
Add AuraCity to Map Games

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Arnis](https://github.com/louis-e/arnis) - Generate cities from real life in Minecraft using Python.
 * [PanoGuessr](https://panoguessr.com/) - A geography game that uses Panoramax to challenge players in identifying locations worldwide from Panoramax images. ([Source Code](https://gitlab.com/panoguessr/panoguessr.com))
 * [PanoramaxGuessr](https://panoramaxguessr.k327.eu/) - A geography game that serves as a FOSS alternative to GeoGuessr, using Panoramax imagery for location identification. ([Source Code](https://codeberg.org/k327/panoramaxguessr))
+* [AuraCity](https://auracity.lol) - A browser game that gives every real-world place an "Aura" score: pick a bar, cafe or park and push it up the city, country and world leaderboards. Places are seeded from Overture Maps, with Overpass as a fallback.
 
 ### Goal Tracking
 


### PR DESCRIPTION
https://auracity.lol

AuraCity is a free browser game that gives every real-world place an "Aura" score. You pick a bar, café, park or museum and push it up the city, country and world leaderboards. No install, no sign-up to play, and it works on mobile web. It currently covers 307,100 places across 512 cities in 120 countries, in English, Spanish and Chinese.

**One thing worth flagging up front so you can judge the fit:** the primary source is Overture Maps (the monthly open Parquet dumps, read with DuckDB), with Overpass as the automatic fallback when a city is not yet seeded — Overpass was the original source and is still what loads a city that Overture misses. OSM and Overture are both credited on the site. If you consider that too indirect for this list, I completely understand — I'd rather say it plainly than have it discovered later.

Added at the bottom of Map Games, per the contribution guidelines. I'm the author.
