### PR TITLE
Add Sperrmüll Bonn to Web Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [Sperrmüll Bonn](https://j4zz.eu/sperrmuell/) - Interactive map for finding bulky-waste collection dates by address in Bonn, Germany, built from the city's open collection-schedule data matched to OSM street geometry. (ℹ️ German only)
 
 ### Mobile Maps
 


### PR DESCRIPTION
Adds Sperrmüll Bonn, a free lookup map for bulky-waste (Sperrmüll) collection dates in Bonn, Germany. Built on the city's own open collection schedule (bonnorange AöR / opendata.bonn.de, CC BY 4.0) matched against OSM street geometry (© OpenStreetMap contributors, ODbL). German-language UI only, flagged accordingly per the existing Defikarte.ch convention.

Repository/source: not published separately; this is the deployed app.