### PR TITLE
Add Calisthenicslivemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This section is a great place to start if you want to get into improving OpenStr
 * [Defikarte.ch](https://www.defikarte.ch) - A Map that shows all available defibrillators in Switzerland and Liechtenstein, also used by emergency dispatch centers and rescue services. (ℹ️ German only)
 * [Streets GL](https://github.com/StrandedKitty/streets-gl) - OpenStreetMap 3D renderer powered by WebGL2. ([Wiki](https://wiki.openstreetmap.org/wiki/Streets_GL))
 * [openclimbing.org](https://openclimbing.org) - A map for rock climbers with editor for creating interactive climbing guides based on OpenStreetMap.
+* [Calisthenicslivemap](https://calisthenicslivemap.com) - A map of outdoor calisthenics and street workout spots worldwide, listing the equipment installed at each location, with facility details drawn from OpenStreetMap.
 
 ### Mobile Maps
 


### PR DESCRIPTION
https://calisthenicslivemap.com

A map of outdoor calisthenics and street workout spots — currently around 28,000 locations across 96 countries. Each location lists the equipment actually installed there (pull-up bars, parallel bars, rings, wall bars), which is the part people need before walking somewhere: playgrounds with child-height bars are a common disappointment.

**OSM relationship, so you can judge the fit:** it renders OSM-based tiles, and per-site facility details are pulled from OpenStreetMap. The spot database itself is community-contributed and cross-referenced against OSM rather than derived from it wholesale.

Added to the bottom of **Maps → Web Maps**, next to thematic POI maps such as Defikarte.ch and openclimbing.org. Free to use, no account required, no ads. Interface in nine languages.

Disclosure: I operate this service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)