### PR TITLE
Add OSM Edit MCP to Native Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ We also have a list of <a href="UNMAINTAINED.md">unmaintained projects</a>. If y
 ### Native Tools
 
 * [Baremaps](https://www.baremaps.com/) - Open source pipeline for producing Mapbox vector tiles from OpenStreetMap with Postgis and Java. ([Source Code](https://github.com/baremaps/baremaps))
+* [OSM Edit MCP](https://github.com/skywinder/osm-edit-mcp) - Alpha Python Model Context Protocol server for analyzing local GPX segments and previewing road edits, with explicit confirmation before production changes.
 
 ### Browser Extensions
 


### PR DESCRIPTION
I maintain [OSM Edit MCP](https://github.com/skywinder/osm-edit-mcp), an alpha Python MCP server for reviewing selected local GPX survey segments and previewing road edits. Production changes require explicit confirmation of the exact proposal in the MCP host and fresh OSM version checks.

This adds one entry at the end of Native Tools. I checked the list and previous issues/PRs for duplicates. The package is available on [PyPI](https://pypi.org/project/osm-edit-mcp/0.2.1/) via `uvx osm-edit-mcp`.
